### PR TITLE
changing name before deploying form:

### DIFF
--- a/app/Jobs/Projects/CheckKoboUpload.php
+++ b/app/Jobs/Projects/CheckKoboUpload.php
@@ -93,13 +93,12 @@ class CheckKoboUpload implements ShouldQueue
 
             // run other actions on Kobo that required a succesfully imported form:
 
-
-            SetKoboFormToActive::withChain([
+            UpdateFormNameOnKobo::withChain([
+                new SetKoboFormToActive($this->user, $this->form),
                 new UploadMediaFileAttachmentsToKoboForm($this->form),
-                new UpdateFormNameOnKobo($this->form),
                 new ShareFormWithProjectMembers($this->form),
                 new DeploymentSuccessMessage($this->user, $this->form),
-            ])->dispatch($this->user, $this->form);
+            ])->dispatch($this->form);
         }
 
     }


### PR DESCRIPTION
 - fixes issue where deployed form doesn't have the name changed