### PR TITLE
Projects control P analysis results columns

### DIFF
--- a/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -37,7 +37,6 @@ class ProjectCrudController extends CrudController
         | CrudPanel Configuration
         |--------------------------------------------------------------------------
         */
-
     }
 
     protected function setupListOperation()
@@ -124,6 +123,16 @@ class ProjectCrudController extends CrudController
                     ],
                 ],
             ],
+            [
+                'name' => 'highR',
+                'label' => 'Does this project need P Analysis outputs split between LR and HR?',
+                'type' => 'boolean',
+            ],
+            [
+                'name' => 'customR',
+                'label' => 'Does this project need extra P Analysis outputs for Custom Reagents?',
+                'type' => 'boolean',
+            ],
         ]);
     }
 
@@ -133,6 +142,5 @@ class ProjectCrudController extends CrudController
     {
         $this->setupCreateOperation();
         $this->crud->setValidation(UpdateRequest::class);
-
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -30,10 +30,10 @@ class ProjectController extends Controller
      * shows the projects in 'All Projects' page that are not deleted and not hidden status.
      * @return [Collection] [projects]
      */
-	public function index()
+    public function index()
     {
-    	$projects = Project::all();
-    	return view('projects.index', compact('projects'));
+        $projects = Project::all();
+        return view('projects.index', compact('projects'));
     }
 
 
@@ -44,26 +44,25 @@ class ProjectController extends Controller
      */
     public function show(Project $project, $tab = null)
     {
-
-        $project = $project->load([
-            'users' => function($q) {
-                $q->orderBy('pivot_admin', 'desc');
-            },
-            'project_xlsforms.xlsform',
+        $project = $project->load(
+            [
+                'users' => function ($q) {
+                    $q->orderBy('pivot_admin', 'desc');
+                },
+                'project_xlsforms.xlsform',
             ]
         );
 
         return view('projects.show', compact('project'));
     }
 
-    public function create ()
+    public function create()
     {
         return view('projects.create');
     }
 
-    public function store (ProjectStoreRequest $request)
+    public function store(ProjectStoreRequest $request)
     {
-
         $validatedData = $request->validated();
 
         $validatedData['creator_id'] = auth()->user()->id;
@@ -74,14 +73,12 @@ class ProjectController extends Controller
         return redirect()->route('projects.show', [$project]);
     }
 
-    public function update (ProjectUpdateRequest $request, Project $project)
+    public function update(ProjectUpdateRequest $request, Project $project)
     {
-
         $this->authorize('update', $project);
-
         $validatedData = $request->validated();
 
-        $project->update(array_filter($validatedData));
+        $project->update($validatedData);
 
         return redirect()->route('projects.show', [$project]);
     }
@@ -99,7 +96,4 @@ class ProjectController extends Controller
 
         return redirect()->route('projects.index');
     }
-
-    
-
 }

--- a/app/Http/Controllers/SampleMergedController.php
+++ b/app/Http/Controllers/SampleMergedController.php
@@ -76,11 +76,7 @@ class SampleMergedController extends Controller
         `analysis_p_lr`.`soil_conc_rounded` AS `analysis_p-soil_conc_rounded`,";
 
         //check if project has any P analyses with High or Custom Reagents
-        if ($project->samples->filter(function ($sample) {
-            return $sample->whereHas('analysis_p', function (Builder $query) {
-                $query->where('reagents', '=', 'HR');
-            });
-        })->count() > 0) {
+        if ($project->highR) {
             $query .= "
             `analysis_p_hr`.`analysis_date` AS `analysis_p_hr-date`,
             `analysis_p_hr`.`weight_soil` AS `analysis_p_hr-weight_soil`,
@@ -100,11 +96,7 @@ class SampleMergedController extends Controller
             `analysis_p_hr`.`soil_conc_rounded` AS `analysis_p_hr-soil_conc_rounded`,";
         }
 
-        if ($project->samples->filter(function ($sample) {
-            return $sample->whereHas('analysis_p', function (Builder $query) {
-                $query->where('reagents', '=', 'Custom R');
-            });
-        })->count() > 0) {
+        if ($project->customR) {
             $query .= "
             `analysis_p_customr`.`analysis_date` AS `analysis_p_custom_r-date`,
             `analysis_p_customr`.`weight_soil` AS `analysis_p_custom_r-weight_soil`,

--- a/app/Http/Requests/ProjectStoreRequest.php
+++ b/app/Http/Requests/ProjectStoreRequest.php
@@ -30,9 +30,11 @@ class ProjectStoreRequest extends FormRequest
             'description' => ['required', 'max:2000'],
             'creator_id' => ['required'],
             'identifiers' => ['sometimes'],
-            'merged_view' => ['sometime'],
+            'merged_view' => ['sometimes'],
             'avatar' => ['nullable'],
             'share_data' => ['boolean'],
+            'highR' => ['sometimes','boolean'],
+            'customR' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/app/Http/Requests/ProjectUpdateRequest.php
+++ b/app/Http/Requests/ProjectUpdateRequest.php
@@ -30,9 +30,11 @@ class ProjectUpdateRequest extends FormRequest
             'description' => ['required', 'max:2000'],
             'creator_id' => ['sometimes'],
             'identifiers' => ['sometimes'],
-            'merged_view' => ['sometime'],
+            'merged_view' => ['sometimes'],
             'avatar' => ['nullable'],
             'share_data' => ['boolean'],
+            'highR' => ['sometimes','boolean'],
+            'customR' => ['sometimes', 'boolean'],
         ];
     }
 

--- a/database/migrations/2020_12_14_125645_add_custom_r_to_projects_table.php
+++ b/database/migrations/2020_12_14_125645_add_custom_r_to_projects_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCustomRToProjectsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->boolean('highR')->default(0)->comment('does this project want split LR and HR results for the Olsen P analysis?');
+            $table->boolean('customR')->default(0)->comment('does this project want extra output columns for Custom R resutls for the Olsen P analysis?');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('highR');
+            $table->dropColumn('customR');
+        });
+    }
+}

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -92,6 +92,66 @@
                     </figure>
                 </div>
             </div>
+            <div class="form-group row">
+                <h5 class="col-md-4 col-form-label text-md-right">
+                    {{ t("Do you need Olsen P Analysis Outputs split between LR and HR?") }}
+                </h5>
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('highR') is-invalid @enderror"
+                        type="radio"
+                        name="highR"
+                        value="1"
+                        id="highR1">
+                    <label class="form-check-label" for="highR1">
+                        {{ t("Yes") }}
+                    </label>
+
+                </div>
+
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('highR') is-invalid @enderror"
+                        type="radio"
+                        name="highR"
+                        value="0"
+                        id="highR_1">
+                    <label class="form-check-label" for="highR_1">
+                        {{ t("No") }}
+                    </label>
+
+                </div>
+            </div>
+            <div class="form-group row">
+                <h5 class="col-md-4 col-form-label text-md-right">
+                    {{ t("Do you need additional Olsen P Analysis Output columns for Custom Reagent packs?") }}
+                </h5>
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('customR') is-invalid @enderror"
+                        type="radio"
+                        name="customR"
+                        value="1"
+                        id="customR1">
+                    <label class="form-check-label" for="customR1">
+                        {{ t("Yes") }}
+                    </label>
+
+                </div>
+
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('customR') is-invalid @enderror"
+                        type="radio"
+                        name="customR"
+                        value="0"
+                        id="customR_1">
+                    <label class="form-check-label" for="customR_1">
+                        {{ t("No") }}
+                    </label>
+
+                </div>
+            </div>
 
             <hr/>
             <h3>{{ t("Project Privacy Settings") }}</h3>

--- a/resources/views/projects/tab-settings.blade.php
+++ b/resources/views/projects/tab-settings.blade.php
@@ -68,6 +68,73 @@
                 </div>
             </div>
 
+            <div class="form-group row">
+                <h5 class="col-md-4 col-form-label text-md-right">
+                    {{ t("Do you need Olsen P Analysis Outputs split between LR and HR?") }}
+                </h5>
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('highR') is-invalid @enderror"
+                        type="radio"
+                        name="highR"
+                        value="1"
+                        id="highR1"
+                        @if($project->highR)checked @endif>
+
+                    <label class="form-check-label" for="highR1">
+                        {{ t("Yes") }}
+                    </label>
+
+                </div>
+
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('highR') is-invalid @enderror"
+                        type="radio"
+                        name="highR"
+                        value="0"
+                        id="highR0"
+                        @if(!$project->highR)checked @endif>
+
+                    <label class="form-check-label" for="highR0">
+                        {{ t("No") }}
+                    </label>
+
+                </div>
+            </div>
+            <div class="form-group row">
+                <h5 class="col-md-4 col-form-label text-md-right">
+                    {{ t("Do you need additional Olsen P Analysis Output columns for Custom Reagent packs?") }}
+                </h5>
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('customR') is-invalid @enderror"
+                        type="radio"
+                        name="customR"
+                        value="1"
+                        id="customR1"
+                        @if($project->customR)checked @endif>
+                    <label class="form-check-label" for="customR1">
+                        {{ t("Yes") }}
+                    </label>
+
+                </div>
+
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input @error('customR') is-invalid @enderror"
+                        type="radio"
+                        name="customR"
+                        value="0"
+                        id="customR0"
+                        @if(!$project->customR)checked @endif>
+                    <label class="form-check-label" for="customR0">
+                        {{ t("No") }}
+                    </label>
+
+                </div>
+            </div>
+
             <hr />
             <h3>{{ t("Project Privacy Settings") }}</h3>
             <p>
@@ -77,22 +144,20 @@
                 {{ t("The data will be suitably anonymised before sharing. Any instances where individual data points might be recognisable will be discussed with the project before being shared publically.") }}
             </p>
 
-    ")) !!}
-
             <div class="form-group row">
                 <h5 class="col-md-4 col-form-label text-md-right">
                     Data Sharing
                 </h5>
                 <div class="col-md-8">
                     <div class="form-check mb-3">
-                        <input class="form-check-input @error('share_data') is-invalid @enderror" type="radio" name="share_data" value="1" id="share_data_1">
+                        <input class="form-check-input @error('share_data') is-invalid @enderror" type="radio" name="share_data" value="1" id="share_data_1" @if($project->share_data)checked @endif>
                         <label class="form-check-label" for="share_data_1">
                             {{ t("I agree to have this project's data to be included in anonymous summaries produced by the CCRP Soils Cross-cutting Project.") }}
                         </label>
 
                     </div>
                     <div class="form-check mb-3">
-                        <input class="form-check-input @error('share_data') is-invalid @enderror" type="radio" name="share_data" value="0" id="share_summary_0" checked>
+                        <input class="form-check-input @error('share_data') is-invalid @enderror" type="radio" name="share_data" value="0" id="share_summary_0" @if(!$project->share_data)checked @endif>
                         <label class="form-check-label" for="share_summary_0">
                             {{ t("Do not include this project's data in summaries produced by the platform for use outside of this project's team.") }}
                         </label>


### PR DESCRIPTION
This PR adds the ability for projects to specify if they want HR and custom R columns for the Analysis P results. By default, projects only receive one set of columns for the Olsen P Analysis results, but sometimes a project may wish to split up the results conducted with Low reactive reagents, High reactive reagents and custom reagent packs. 