### PR TITLE
Finetune performance for project page loading time

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -50,7 +50,7 @@ class ProjectController extends Controller
                 'users' => function ($q) {
                     $q->orderBy('pivot_admin', 'desc');
                 },
-                'project_xlsforms.xlsform',
+                # 'project_xlsforms.xlsform',
                 'samples',
             ]
         );

--- a/app/Models/Projectxlsform.php
+++ b/app/Models/Projectxlsform.php
@@ -78,12 +78,12 @@ class ProjectXlsform extends Pivot
         $project_name = str_replace('/', '_', $this->project->name);
         $form_name = str_replace('/', '_', $this->xlsform->title);
 
-        return $project_name.' - '.$form_name;
+        return $project_name . ' - ' . $form_name;
     }
 
     public function getRecordsAttribute()
     {
-        return $this->project_submissions->count();
+        return $this->project_submissions()->count();
     }
 
 

--- a/resources/js/components/ProjectDataTable.vue
+++ b/resources/js/components/ProjectDataTable.vue
@@ -10,7 +10,7 @@
                     <th rowspan="2">{{ __("vue.Sample ID") }}</th>
 
                     <th
-                        v-for="identifier in project.identifiers"
+                        v-for="identifier in projectIdentifiers"
                         :key="identifier.name"
                         rowspan="2">
                         {{ identifier.label }}
@@ -50,7 +50,7 @@
 
 
                     <td
-                        v-for="identifier in project.identifiers"
+                        v-for="identifier in projectIdentifiers"
                         :key="identifier.name"
                     >
                         {{ sample.identifiers ? sample.identifiers[identifier.name] : ''}}
@@ -77,7 +77,7 @@
 </template>
 <script>
     export default {
-        props: ["project", "userId", "samples"],
+        props: ["projectIdentifiers", "userId", "samples"],
 
         data() {
             return {
@@ -87,7 +87,7 @@
             };
         },
         mounted: function() {
-            console.log(this.project.identifiers);
+            console.log(this.projectIdentifiers);
 
             // round things for display
             this.samplesDisplay = this.samples.map(sample => {

--- a/resources/js/components/ProjectFormsTable.vue
+++ b/resources/js/components/ProjectFormsTable.vue
@@ -79,7 +79,7 @@
 
     const rootUrl = process.env.MIX_APP_URL
     export default {
-        props: ['project','userId'],
+        props: ['projectSlug','userId'],
         data() {
             return {
                 projectForms: [],
@@ -94,7 +94,7 @@
 
         mounted() {
 
-            axios.get(rootUrl+'/projects/'+this.project.slug+'/projectxlsforms')
+            axios.get(rootUrl+'/projects/'+this.projectSlug+'/projectxlsforms')
             .then((response) => {
                 this.projectForms = response.data
             })

--- a/resources/js/components/ProjectNutrientsTable.vue
+++ b/resources/js/components/ProjectNutrientsTable.vue
@@ -14,7 +14,7 @@
 </template>
 <script>
 export default {
-    props: ['project'],
+    props: ['projectId'],
 
     data() {
         return {
@@ -54,16 +54,11 @@ export default {
         }
     },
     mounted: function(){
-        var project_id = this.project.id;
-
-        axios.get(`/nutrientbalance/${project_id}/json`)
+        axios.get(`/nutrientbalance/${projectId}/json`)
         .then((res) => {
             this.nutrientBalances = res.data;
         })
-
-
     }
-
 
 }
 </script>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -38,7 +38,6 @@
                 <!-- to pass project slug as a string to Vue component, wrap string value with single quote -->
                 <project-forms-table
                 :project-slug="'{{ $project->slug }}'"
-                :project-forms="{{ $project->project_xlsforms->toJson() }}"
                 :user-id="{{ auth()->user()->id }}"
                 >
                 </project-forms-table>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -35,8 +35,9 @@
                     {{ t("You still have access to all the data collected with these forms.") }}
                 </div>
             @endif
+                <!-- to pass project slug as a string to Vue component, wrap string value with single quote -->
                 <project-forms-table
-                :project="{{ $project->toJson() }}"
+                :project-slug="'{{ $project->slug }}'"
                 :project-forms="{{ $project->project_xlsforms->toJson() }}"
                 :user-id="{{ auth()->user()->id }}"
                 >
@@ -61,7 +62,7 @@
             <a href="{{ route('projects.samples.download-wide', $project) }}" class="btn btn-success">{{ t("Download sample data in wide format") }}</a>
             <a href="{{ route('projects.samples.download-long', $project) }}" class="btn btn-success">{{ t("Download sample data in split format") }}</a>
             <project-data-table
-                :project="{{ $project->toJson() }}"
+                :project-identifiers="{{ json_encode($project->identifiers) }}"
                 :user-id="{{ auth()->user()->id }}"
                 :samples="{{ $project->samples->toJson() }}"
             ></project-data-table>
@@ -71,7 +72,7 @@
             <p></p>
             <p>Note: Press [Shift] + mouse wheel to scroll horizontally</p>
             <project-nutrients-table
-                :project="{{ $project->toJson() }}"
+                :project-id="{{ $project->id }}"
                 :user-id="{{ auth()->user()->id }}">
             </project-nutrients-table>
         </div>


### PR DESCRIPTION
Changes:
 - Only embed required data to Vue components in HTML page instead of embedding the whole project object


Checking and Findings:
 - For "Anchor Hub Trails" project, it takes 45 and 33 seconds to load in local env and live env respectively
 - View loaded page source code in browser, save it in a file, the whole project object in JSON format appeared three times
 - One project JSON is 3.8 MB, 3 project JSON is 3.8 x 3 = 11.4 MB
 - Large HTML page source code is the major cause of project page long loading time

![image](https://user-images.githubusercontent.com/86968034/162417479-88f43ba5-fdbc-4cf3-b150-120dd2baaac5.png)


Short Term Improvement:
 - Review what data items are required in the corresponding Vue component
 - Only pass the required data item instead of passing the whole project object into Vue compoenent
 - It is a short term improvement only because when we have many many samples data, it will take a long time to load the project page


Long Term Improvements:
 - XLSForms is passed as JSON to Vue component now. As we should have limited number of XLSForms records, it is unlikely to cause performance issue
 - Currently nutrients data is loaded vis axios, samples data is loaded by passing all samples data into Vue component
 - To avoid project page has long loading time issue permanently, it is recommended to modify program to load samples data via axios
 - Therefore, the page loading and data loading (samples data and nutrients data) are separated. When there are many records, the page will be showed in browser first, samples data and nutrients data will be showed after data retrieved via axios
 - We can apply short term improvement for immeidate help. Long term improvement will be developed in another branch.
