### PR TITLE
fix sample downloads for projects with non-standard characters in the name

### DIFF
--- a/app/Http/Controllers/SampleController.php
+++ b/app/Http/Controllers/SampleController.php
@@ -12,7 +12,7 @@ class SampleController extends Controller
 {
     public function download(Project $project)
     {
-        $filename = $project->name . '-samples-' . now()->toDateTimeString() . '.xlsx';
+        $filename = $project->slug . '-samples-' . now()->toDateTimeString() . '.xlsx';
 
         return Excel::download(new SoilWorkbookExport($project), $filename);
     }

--- a/app/Http/Controllers/SampleMergedController.php
+++ b/app/Http/Controllers/SampleMergedController.php
@@ -15,7 +15,7 @@ class SampleMergedController extends Controller
     public function download(Project $project)
     {
         $date = Carbon::now()->toDateTimeString();
-        return (new SampleMergedExport)->forProject($project)->download($project->name.'-all_sample_data-'.$date.".xlsx");
+        return (new SampleMergedExport)->forProject($project)->download($project->slug . '-all_sample_data-' . $date . ".xlsx");
     }
 
     public static function createCustomView(Project $project)
@@ -175,9 +175,9 @@ class SampleMergedController extends Controller
         LEFT JOIN `analysis_agg` ON ((`samples`.`id` = `analysis_agg`.`sample_id`)))";
 
         // create or update file in databases views folder
-        $projectSnakeName = "samples_merged_".Str::of($project->name)->slug('_');
+        $projectSnakeName = "samples_merged_" . Str::of($project->name)->slug('_');
 
-        file_put_contents(base_path('database/views/'.$projectSnakeName.'.sql'), $query);
+        file_put_contents(base_path('database/views/' . $projectSnakeName . '.sql'), $query);
 
         // rerun view creation
         Artisan::call('updatesql');


### PR DESCRIPTION
Recreating the hotfix applied directly to the server back in March, to help out Steve during a working session with the EP&D/Nelson Mandella project. 

This fixes an issue caused when a user tries to download a sample data export from  a project with charcters like "/" in the name, that cannot become charcters in a filename.  